### PR TITLE
Inline showing of graph plotted via matplotlib

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -56,6 +56,7 @@
    "source": [
     "# Importing matplotlib\n",
     "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
     "\n",
     "# Function to help us plot\n",
     "def plot_points(data):\n",


### PR DESCRIPTION
Added %matplotlib inline, or none of the graphs plotted won't be shown after plt.show()