### PR TITLE
Missing NumPy import

### DIFF
--- a/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
+++ b/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
@@ -269,6 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    import numpy as np
     "a = np.random.rand(4,3)\n",
     "a"
    ]


### PR DESCRIPTION
In "Numpy to Torch and back" we are calling "np.random.rand", but nowhere in the code do we import numpy.
Consider adding an import statement before calling it or at the very top of the code with "import torch".