### PR TITLE
add an alternative solution for one hot encoding

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissionsSolutions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissionsSolutions.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Make dummy variables for rank\n",
@@ -27,6 +25,19 @@
     "\n",
     "# Drop the previous rank column\n",
     "one_hot_data = one_hot_data.drop('rank', axis=1)\n",
+    "\n",
+    "# Print the first 10 rows of our data\n",
+    "one_hot_data[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Alternative solution for one hot encoding without needing to drop column\n",
+    "one_hot_data = pd.get_dummies(data, columns=['rank'])\n",
     "\n",
     "# Print the first 10 rows of our data\n",
     "one_hot_data[:10]"
@@ -42,9 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Copying our data\n",
@@ -66,9 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def error_term_formula(x, y, output):\n",
@@ -77,10 +84,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "## alternative solution ##\n",
@@ -95,7 +100,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -109,7 +114,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the StudentAdmissionsSolutions Notebook, added an one liner alternative solution for the following:
```python
# Make dummy variables for rank
one_hot_data = pd.concat([data, pd.get_dummies(data['rank'], prefix='rank')], axis=1)
# Drop the previous rank column
one_hot_data = one_hot_data.drop('rank', axis=1)
```
These  code segment can be replaced with one liner
```python
one_hot_data = pd.get_dummies(data, columns=['rank'])
```