### PR TITLE
Change Part-3 Exercise output probability calculation from softmax to torch.exp

### DIFF
--- a/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
+++ b/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
@@ -463,10 +463,10 @@
     "img = images[0].view(1, 784)\n",
     "# Turn off gradients to speed up this part\n",
     "with torch.no_grad():\n",
-    "    logits = model.forward(img)\n",
+    "    logps = model.forward(img)\n",
     "\n",
     "# Output of the network are logits, need to take softmax for probabilities\n",
-    "ps = F.softmax(logits, dim=1)\n",
+    "ps = torch.exp(logps)\n",
     "helper.view_classify(img.view(1, 28, 28), ps)"
    ]
   },

--- a/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
+++ b/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
@@ -465,7 +465,7 @@
     "with torch.no_grad():\n",
     "    logps = model.forward(img)\n",
     "\n",
-    "# Output of the network are logits, need to take softmax for probabilities\n",
+    "# Output of the network are log of probabilities, need to calculate exp for probabilities\n",
     "ps = torch.exp(logps)\n",
     "helper.view_classify(img.view(1, 28, 28), ps)"
    ]

--- a/intro-to-pytorch/Part 3 - Training Neural Networks (Solution).ipynb
+++ b/intro-to-pytorch/Part 3 - Training Neural Networks (Solution).ipynb
@@ -627,7 +627,7 @@
     "with torch.no_grad():\n",
     "    logps = model.forward(img)\n",
     "\n",
-    "# Output of the network are logits, need to take softmax for probabilities\n",
+    "# Output of the network are log of probabilities, need to calculate exp for probabilities\n",
     "ps = torch.exp(logps)\n",
     "helper.view_classify(img.view(1, 28, 28), ps)"
    ]


### PR DESCRIPTION
In _"Part 3 Training Neural Networks (Exercise)"_ final part, output probabilities are calculated using **softmax** whereas in solution **torch.exp** is used. Torch.exp is the correct function since LogSoftmax is intended to be used.

Also comment is _"# Output of the network are logits, need to take softmax for probabilities"_ in both exercise and solution. I've changed it by _"# Output of the network are log of probabilities, need to calculate exp for probabilities"_