### PR TITLE
Remove matrix multiplication

### DIFF
--- a/recurrent-neural-networks/char-rnn/Character_Level_RNN_Exercise.ipynb
+++ b/recurrent-neural-networks/char-rnn/Character_Level_RNN_Exercise.ipynb
@@ -142,7 +142,7 @@
     "def one_hot_encode(arr, n_labels):\n",
     "    \n",
     "    # Initialize the the encoded array\n",
-    "    one_hot = np.zeros((np.multiply(*arr.shape), n_labels), dtype=np.float32)\n",
+    "    np.zeros((arr.size, n_labels), dtype=np.float32)\n",
     "    \n",
     "    # Fill the appropriate elements with ones\n",
     "    one_hot[np.arange(one_hot.shape[0]), arr.flatten()] = 1.\n",


### PR DESCRIPTION
Numpy arrays have a property called 'size' there is no need to use matrix multiplication on shapes