### PR TITLE
Fix crash when using an uneven batch size

### DIFF
--- a/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
+++ b/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
@@ -309,7 +309,7 @@
     "    # compare predictions to true label\n",
     "    correct = np.squeeze(pred.eq(target.data.view_as(pred)))\n",
     "    # calculate test accuracy for each object class\n",
-    "    for i in range(batch_size):\n",
+    "    for i in range(len(target)):\n",
     "        label = target.data[i]\n",
     "        class_correct[label] += correct[i].item()\n",
     "        class_total[label] += 1\n",

--- a/convolutional-neural-networks/mnist-mlp/mnist_mlp_solution.ipynb
+++ b/convolutional-neural-networks/mnist-mlp/mnist_mlp_solution.ipynb
@@ -424,7 +424,7 @@
     "    # compare predictions to true label\n",
     "    correct = np.squeeze(pred.eq(target.data.view_as(pred)))\n",
     "    # calculate test accuracy for each object class\n",
-    "    for i in range(batch_size):\n",
+    "    for i in range(len(target)):\n",
     "        label = target.data[i]\n",
     "        class_correct[label] += correct[i].item()\n",
     "        class_total[label] += 1\n",

--- a/convolutional-neural-networks/mnist-mlp/mnist_mlp_solution_with_validation.ipynb
+++ b/convolutional-neural-networks/mnist-mlp/mnist_mlp_solution_with_validation.ipynb
@@ -509,7 +509,7 @@
     "    # compare predictions to true label\n",
     "    correct = np.squeeze(pred.eq(target.data.view_as(pred)))\n",
     "    # calculate test accuracy for each object class\n",
-    "    for i in range(batch_size):\n",
+    "    for i in range(len(target)):\n",
     "        label = target.data[i]\n",
     "        class_correct[label] += correct[i].item()\n",
     "        class_total[label] += 1\n",


### PR DESCRIPTION
When we use a batch of size 64 with the MNIST dataset, the last test batch will have size 16.

The current code will not dynamically adjust the batch size, thus, crashing during validation because it will assume all batch have size 64.

This fix simply computes the batch size correctly when needed.