### PR TITLE
Update TODO comment in StudentAdmissions Notebook

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -130,7 +130,7 @@
    },
    "outputs": [],
    "source": [
-    "# TODO:  Make dummy variables for rank\n",
+    "# TODO:  Make dummy variables for rank and concat existing columns\n",
     "one_hot_data = pass\n",
     "\n",
     "# TODO: Drop the previous rank column\n",


### PR DESCRIPTION
It's hard to guess from the current "todo" that we are supposed to concat the columns from `data` in `one_hot_data`. Frankly, I had to look solution for this,