### PR TITLE
Fixed method invocation in instructions

### DIFF
--- a/style-transfer/Style_Transfer_Exercise.ipynb
+++ b/style-transfer/Style_Transfer_Exercise.ipynb
@@ -261,7 +261,7 @@
     "## Gram Matrix \n",
     "\n",
     "The output of every convolutional layer is a Tensor with dimensions associated with the `batch_size`, a depth, `d` and some height and width (`h`, `w`). The Gram matrix of a convolutional layer can be calculated as follows:\n",
-    "* Get the depth, height, and width of a tensor using `batch_size, d, h, w = tensor.size`\n",
+    "* Get the depth, height, and width of a tensor using `batch_size, d, h, w = tensor.size()`\n",
     "* Reshape that tensor so that the spatial dimensions are flattened\n",
     "* Calculate the gram matrix by multiplying the reshaped tensor by it's transpose \n",
     "\n",


### PR DESCRIPTION
Missing parentheses on size method of Tensor object in instructions