### PR TITLE
Fix issue #95 - RuntimeError

### DIFF
--- a/sentiment-rnn/Sentiment_RNN_Solution.ipynb
+++ b/sentiment-rnn/Sentiment_RNN_Solution.ipynb
@@ -676,6 +676,7 @@
     "        batch_size = x.size(0)\n",
     "\n",
     "        # embeddings and lstm_out\n",
+    "        x = x.long()\n",
     "        embeds = self.embedding(x)\n",
     "        lstm_out, hidden = self.lstm(embeds, hidden)\n",
     "    \n",


### PR DESCRIPTION
Fix for the following error:
> RuntimeError: Expected tensor for argument #1 'indices' to have scalar type Long; but got CUDAIntTensor instead (while checking arguments for embedding)

Just added the line `x = x.long()` in the `forward` function before the embedding layer.