### PR TITLE
Error term correction

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissionsSolutions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissionsSolutions.ipynb
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "def error_term_formula(x, y, output):\n",
-    "    return (y - output)*sigmoid_prime(x)"
+    "    return (y - output)"
    ]
   },
   {
@@ -82,15 +82,6 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": [
-    "## alternative solution ##\n",
-    "# you could also *only* use y and the output \n",
-    "# and calculate sigmoid_prime directly from the activated output!\n",
-    "\n",
-    "# below is an equally valid solution (it doesn't utilize x)\n",
-    "def error_term_formula(x, y, output):\n",
-    "    return (y-output) * output * (1 - output)"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Please check course material under 23. Gradient Descent. 

Gradient Descent Step stated clearly for sigmoid binary cross-entropy error (which suits the student admission case) the GD step should be: 

w + a * (y - output) * x

There is no sigmoid prime required again.