### PR TITLE
split_frac

### DIFF
--- a/sentiment-rnn/Sentiment_RNN_Solution.ipynb
+++ b/sentiment-rnn/Sentiment_RNN_Solution.ipynb
@@ -465,7 +465,7 @@
     "\n",
     "## split data into training, validation, and test data (features and labels, x and y)\n",
     "\n",
-    "split_idx = int(len(features)*0.8)\n",
+    "split_idx = int(len(features)*split_frac)\n",
     "train_x, remaining_x = features[:split_idx], features[split_idx:]\n",
     "train_y, remaining_y = encoded_labels[:split_idx], encoded_labels[split_idx:]\n",
     "\n",


### PR DESCRIPTION
split_frac is defined in the exercise instructions, is defined as equal to 0.8 but is not used later.
We should replace the 0.8 in the following line by split_frac, that way we define the split fraction once.