### PR TITLE
filter size fix in documentation

### DIFF
--- a/convolutional-neural-networks/conv-visualization/conv_visualization.ipynb
+++ b/convolutional-neural-networks/conv-visualization/conv_visualization.ipynb
@@ -124,7 +124,7 @@
     "#### `__init__` and `forward`\n",
     "To define a neural network in PyTorch, you define the layers of a model in the function `__init__` and define the forward behavior of a network that applyies those initialized layers to an input (`x`) in the function `forward`. In PyTorch we convert all inputs into the Tensor datatype, which is similar to a list data type in Python. \n",
     "\n",
-    "Below, I define the structure of a class called `Net` that has a convolutional layer that can contain four 3x3 grayscale filters."
+    "Below, I define the structure of a class called `Net` that has a convolutional layer that can contain four 4x4 grayscale filters."
    ]
   },
   {


### PR DESCRIPTION
In the documentation part of this notebook it describes the 4 grayscale filters as being 3x3 but they appear to be 4x4.