### PR TITLE
Trasferring 'current_seq' to CPU from GPU

### DIFF
--- a/project-tv-script-generation/dlnd_tv_script_generation.ipynb
+++ b/project-tv-script-generation/dlnd_tv_script_generation.ipynb
@@ -786,6 +786,8 @@
     "        word = int_to_vocab[word_i]\n",
     "        predicted.append(word)     \n",
     "        \n",
+    "        if(train_on_gpu):\n",
+    "            current_seq = current_seq.cpu() # move to cpu\n",
     "        # the generated word becomes the next \"current sequence\" and the cycle can continue\n",
     "        current_seq = np.roll(current_seq, -1, 1)\n",
     "        current_seq[-1][-1] = word_i\n",


### PR DESCRIPTION
We should transfer 'current_seq' to CPU from GPU, to prevent error.