### PR TITLE
Fixed a TypeError in GPU-enabled environments

### DIFF
--- a/convolutional-neural-networks/cifar-cnn/cifar10_cnn_solution.ipynb
+++ b/convolutional-neural-networks/cifar-cnn/cifar10_cnn_solution.ipynb
@@ -639,7 +639,7 @@
     "fig = plt.figure(figsize=(25, 4))\n",
     "for idx in np.arange(20):\n",
     "    ax = fig.add_subplot(2, 20/2, idx+1, xticks=[], yticks=[])\n",
-    "    imshow(images[idx])\n",
+    "    imshow(images.cpu()[idx])\n",
     "    ax.set_title(\"{} ({})\".format(classes[preds[idx]], classes[labels[idx]]),\n",
     "                 color=(\"green\" if preds[idx]==labels[idx].item() else \"red\"))"
    ]


### PR DESCRIPTION
For GPU-enabled environments, the following error is encountered in the original code
TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.