### PR TITLE
Correct some typos in dog classification project

### DIFF
--- a/project-dog-classification/dog_app.ipynb
+++ b/project-dog-classification/dog_app.ipynb
@@ -50,7 +50,7 @@
     "Make sure that you've downloaded the required human and dog datasets:\n",
     "* Download the [dog dataset](https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/dogImages.zip).  Unzip the folder and place it in this project's home directory, at the location `/dogImages`. \n",
     "\n",
-    "* Download the [human dataset](https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/lfw.zip).  Unzip the folder and place it in the home diretcory, at location `/lfw`.  \n",
+    "* Download the [human dataset](https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/lfw.zip).  Unzip the folder and place it in the home directory, at location `/lfw`.  \n",
     "\n",
     "*Note: If you are using a Windows machine, you are encouraged to use [7zip](http://www.7-zip.org/) to extract the folder.*\n",
     "\n",
@@ -213,7 +213,7 @@
    "outputs": [],
    "source": [
     "### (Optional) \n",
-    "### TODO: Test performance of anotherface detection algorithm.\n",
+    "### TODO: Test performance of another face detection algorithm.\n",
     "### Feel free to use as many code cells as needed."
    ]
   },
@@ -478,7 +478,7 @@
     "        ## Define forward behavior\n",
     "        return x\n",
     "\n",
-    "#-#-# You so NOT have to modify the code below this line. #-#-#\n",
+    "#-#-# You do NOT have to modify the code below this line. #-#-#\n",
     "\n",
     "# instantiate the CNN\n",
     "model_scratch = Net()\n",
@@ -824,7 +824,7 @@
     "- if a __human__ is detected in the image, return the resembling dog breed.\n",
     "- if __neither__ is detected in the image, provide output that indicates an error.\n",
     "\n",
-    "You are welcome to write your own functions for detecting humans and dogs in images, but feel free to use the `face_detector` and `human_detector` functions developed above.  You are __required__ to use your CNN from Step 4 to predict dog breed.  \n",
+    "You are welcome to write your own functions for detecting humans and dogs in images, but feel free to use the `face_detector` and `dog_detector` functions developed above.  You are __required__ to use your CNN from Step 4 to predict dog breed.  \n",
     "\n",
     "Some sample output for our algorithm is provided below, but feel free to design your own user experience!\n",
     "\n",


### PR DESCRIPTION
This change addresses a few minor typos, including one change that is slightly
confusing (refering to non-existent function `human_detector` which should be
`dog_detecor`).