### PR TITLE
fix: corrects wrong comment. The image is expected to be in range 0-1…

### DIFF
--- a/cycle-gan/CycleGAN_Exercise.ipynb
+++ b/cycle-gan/CycleGAN_Exercise.ipynb
@@ -233,7 +233,7 @@
     "def scale(x, feature_range=(-1, 1)):\n",
     "    ''' Scale takes in an image x and returns that image, scaled\n",
     "       with a feature_range of pixel values from -1 to 1. \n",
-    "       This function assumes that the input x is already scaled from 0-255.'''\n",
+    "       This function assumes that the input x is already scaled from 0-1.'''\n",
     "    \n",
     "    # scale from 0-1 to feature_range\n",
     "    min, max = feature_range\n",


### PR DESCRIPTION
Corrects wrong comment: The image is expected to be in range 0-1 not in range 0-255. Corrects the comment for the exercise as well as the solution file.