### PR TITLE
Ensure sequence is moved to CPU

### DIFF
--- a/project-tv-script-generation/dlnd_tv_script_generation.ipynb
+++ b/project-tv-script-generation/dlnd_tv_script_generation.ipynb
@@ -787,6 +787,8 @@
     "        predicted.append(word)     \n",
     "        \n",
     "        # the generated word becomes the next \"current sequence\" and the cycle can continue\n",
+    "        if train_on_gpu:\n",
+    "            current_seq = current_seq.cpu()\n",
     "        current_seq = np.roll(current_seq, -1, 1)\n",
     "        current_seq[-1][-1] = word_i\n",
     "    \n",


### PR DESCRIPTION
In the TV script generation project, the generate() function erroneously
continues to use the current_seq value without first moving to CPU (if training
on GPU). This can lead to an error of the form shown below:

"TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the
tensor to host memory first."

Resolves: #118