### PR TITLE
Fix test time error in project-tv-script-generation

### DIFF
--- a/project-tv-script-generation/dlnd_tv_script_generation.ipynb
+++ b/project-tv-script-generation/dlnd_tv_script_generation.ipynb
@@ -787,7 +787,7 @@
     "        predicted.append(word)     \n",
     "        \n",
     "        # the generated word becomes the next \"current sequence\" and the cycle can continue\n",
-    "        current_seq = np.roll(current_seq, -1, 1)\n",
+    "        current_seq = np.roll(current_seq.cpu(), -1, 1)\n",
     "        current_seq[-1][-1] = word_i\n",
     "    \n",
     "    gen_sentences = ' '.join(predicted)\n",


### PR DESCRIPTION
When the model has been trained on gpu and train_on_gpu=True, current_seq = np.roll(current_seq.cpu(), -1, 1) doesn't work with cuda tensors and outputs the error: TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first. Forcing .cpu() fix the issue and add little overhead for cpu models.