### PR TITLE
Change transforms.Normalize() arguments after upgrade torchvision to 0.2.2

### DIFF
--- a/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
+++ b/intro-to-pytorch/Part 3 - Training Neural Networks (Exercises).ipynb
@@ -86,7 +86,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),\n",
+    "                                transforms.Normalize((0.5,), (0.5,)),\n",
     "                              ])\n",
     "# Download and load the training data\n",
     "trainset = datasets.MNIST('~/.pytorch/MNIST_data/', download=True, train=True, transform=transform)\n",

--- a/intro-to-pytorch/Part 3 - Training Neural Networks (Solution).ipynb
+++ b/intro-to-pytorch/Part 3 - Training Neural Networks (Solution).ipynb
@@ -86,7 +86,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),\n",
+    "                                transforms.Normalize((0.5,), (0.5,)),\n",
     "                              ])\n",
     "# Download and load the training data\n",
     "trainset = datasets.MNIST('~/.pytorch/MNIST_data/', download=True, train=True, transform=transform)\n",

--- a/intro-to-pytorch/Part 4 - Fashion-MNIST (Exercises).ipynb
+++ b/intro-to-pytorch/Part 4 - Fashion-MNIST (Exercises).ipynb
@@ -27,7 +27,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('~/.pytorch/F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/intro-to-pytorch/Part 4 - Fashion-MNIST (Solution).ipynb
+++ b/intro-to-pytorch/Part 4 - Fashion-MNIST (Solution).ipynb
@@ -27,7 +27,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('~/.pytorch/F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/intro-to-pytorch/Part 5 - Inference and Validation (Exercises).ipynb
+++ b/intro-to-pytorch/Part 5 - Inference and Validation (Exercises).ipynb
@@ -28,7 +28,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('~/.pytorch/F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",

--- a/intro-to-pytorch/Part 5 - Inference and Validation (Solution).ipynb
+++ b/intro-to-pytorch/Part 5 - Inference and Validation (Solution).ipynb
@@ -28,7 +28,7 @@
     "\n",
     "# Define a transform to normalize the data\n",
     "transform = transforms.Compose([transforms.ToTensor(),\n",
-    "                                transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])\n",
+    "                                transforms.Normalize((0.5,), (0.5,))])\n",
     "# Download and load the training data\n",
     "trainset = datasets.FashionMNIST('~/.pytorch/F_MNIST_data/', download=True, train=True, transform=transform)\n",
     "trainloader = torch.utils.data.DataLoader(trainset, batch_size=64, shuffle=True)\n",


### PR DESCRIPTION
after I update torchvision to 0.2.2, 
transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)) will cause below error:
RuntimeError: output with shape [1, 28, 28] doesn't match the broadcast shape [3, 28, 28]

need change to 
transforms.Normalize((0.5,), (0.5,))