### PR TITLE
Commands to fetch datasets directly to workspace

### DIFF
--- a/project-dog-classification/dog_app.ipynb
+++ b/project-dog-classification/dog_app.ipynb
@@ -65,6 +65,25 @@
    },
    "outputs": [],
    "source": [
+    "# Jupyter executable commands for downloading and extracting datasets to /dogImages folder \n",
+    "!wget -qq https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/dogImages.zip\n",
+    "!unzip -qq dogImages.zip\n",
+    "!rm dogImages.zip\n",
+    "\n",
+    "!wget -qq https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/lfw.zip\n",
+    "!unzip -qq lfw.zip\n",
+    "!rm lfw.zip\n",
+    "!rm -r __MACOSX"
+   ]
+  },	 
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "from glob import glob\n",
     "\n",

--- a/project-dog-classification/dog_app.ipynb
+++ b/project-dog-classification/dog_app.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "# Jupyter executable commands for downloading and extracting datasets to /dogImages folder \n",
+    "# Jupyter executable commands for downloading and extracting datasets to the home directory \n",
     "!wget -qq https://s3-us-west-1.amazonaws.com/udacity-aind/dog-project/dogImages.zip\n",
     "!unzip -qq dogImages.zip\n",
     "!rm dogImages.zip\n",


### PR DESCRIPTION
I've added Jupyter commands which when executed will directly download the datasets to the /dogImages folder in Udacity workspace, extract them and then delete the residual zip files.
Students need not download zips to their local PCs, extract them and then upload folders to udacity.