### PR TITLE
Add zero_grad to Transfer Learning notebook

### DIFF
--- a/intro-to-pytorch/Part 8 - Transfer Learning (Exercises).ipynb
+++ b/intro-to-pytorch/Part 8 - Transfer Learning (Exercises).ipynb
@@ -149,6 +149,8 @@
     "\n",
     "        outputs = model.forward(inputs)\n",
     "        loss = criterion(outputs, labels)\n",
+    "\n",
+    "        optimizer.zero_grad()\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
     "\n",


### PR DESCRIPTION
We are missing zero_grad in example, which can cause gradients to accumulate if not caught.