### PR TITLE
Add missing activation function

### DIFF
--- a/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Solution).ipynb
+++ b/intro-to-pytorch/Part 2 - Neural Networks in PyTorch (Solution).ipynb
@@ -398,7 +398,7 @@
    "source": [
     "### Activation functions\n",
     "\n",
-    "So far we've only been looking at the softmax activation, but in general any function can be used as an activation function. The only requirement is that for a network to approximate a non-linear function, the activation functions must be non-linear. Here are a few more examples of common activation functions: Tanh (hyperbolic tangent), and ReLU (rectified linear unit).\n",
+    "So far we've only been looking at the sigmoid and softmax activation functions, but in general any function can be used as an activation function. The only requirement is that for a network to approximate a non-linear function, the activation functions must be non-linear. Here are a few more examples of common activation functions: Tanh (hyperbolic tangent), and ReLU (rectified linear unit).\n",
     "\n",
     "<img src=\"assets/activation.png\" width=700px>\n",
     "\n",


### PR DESCRIPTION
In the 'Activation Functions' cell, it mentions that, so far, we have only used softmax as an activation function.

I would say when we have been using both sigmoid and softmax as activation functions.