### PR TITLE
Fix typo in explanation of matrix multiplication

### DIFF
--- a/intro-to-pytorch/Part 1 - Tensors in PyTorch (Solution).ipynb
+++ b/intro-to-pytorch/Part 1 - Tensors in PyTorch (Solution).ipynb
@@ -150,7 +150,7 @@
     "RuntimeError: size mismatch, m1: [1 x 5], m2: [1 x 5] at /Users/soumith/minicondabuild3/conda-bld/pytorch_1524590658547/work/aten/src/TH/generic/THTensorMath.c:2033\n",
     "```\n",
     "\n",
-    "As you're building neural networks in any framework, you'll see this often. Really often. What's happening here is our tensors aren't the correct shapes to perform a matrix multiplication. Remember that for matrix multiplications, the number of columns in the first tensor must equal to the number of rows in the second column. Both `features` and `weights` have the same shape, `(1, 5)`. This means we need to change the shape of `weights` to get the matrix multiplication to work.\n",
+    "As you're building neural networks in any framework, you'll see this often. Really often. What's happening here is our tensors aren't the correct shapes to perform a matrix multiplication. Remember that for matrix multiplications, the number of columns in the first tensor must equal to the number of rows in the second tensor. Both `features` and `weights` have the same shape, `(1, 5)`. This means we need to change the shape of `weights` to get the matrix multiplication to work.\n",
     "\n",
     "**Note:** To see the shape of a tensor called `tensor`, use `tensor.shape`. If you're building neural networks, you'll be using this method often.\n",
     "\n",


### PR DESCRIPTION
Changed the word column to the word tensor in the description of the right sizes of the tensors to perform matrix multiplication.