### PR TITLE
fix: Clarify output dimension from cyclegan discriminators

### DIFF
--- a/cycle-gan/CycleGAN_Exercise.ipynb
+++ b/cycle-gan/CycleGAN_Exercise.ipynb
@@ -271,7 +271,7 @@
     "\n",
     "<img src='notebook_images/discriminator_layers.png' width=80% />\n",
     "\n",
-    "This network sees a 128x128x3 image, and passes it through 5 convolutional layers that downsample the image by a factor of 2. The first four convolutional layers have a BatchNorm and ReLu activation function applied to their output, and the last acts as a classification layer that outputs one value.\n",
+    "This network sees a 128x128x3 image, and passes it through 5 convolutional layers that downsample the image by a factor of 2. The first four convolutional layers have a BatchNorm and ReLu activation function applied to their output, and the last acts as a classification layer that outputs a prediction map with depth of one. Contrary to what the figure above indicates, the final output is not required to have a width and depth of one. In the original paper, the authors passed a 4x4 kernel with stride of 1 in the final convolutional layer. You should replicate that strategy.\n",
     "\n",
     "### Convolutional Helper Function\n",
     "\n",
@@ -1035,7 +1035,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1049,7 +1049,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi! I'm taking the deep learning Nanodegree and got confused in what the output of the discriminator in the cycle gan should be. The source of my confusion was that the image implies that the output should be a 1x1x1 tensor (which would require an 8x8 kernel with zero padding), but the solution notebook used a 4x4 kernel. I looked at the original paper and [code repository](https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix/blob/master/models/networks.py) and figured that that was correct. The reason being we wish to output a prediction map, not a single prediction value. I think the figure is misleading in this way. I cannot change it but tried adding a few lines in the notebook to clarify what the final convolutional layer in the discriminator is doing. I'm not sure whether I explained it clearly, but I'd appreciate if you could find a way of clarifying that point since I thought it was a source of confusion. Thank you!