### PR TITLE
changing .ix to .iloc for indexing

### DIFF
--- a/project-bikesharing/Predicting_bike_sharing_data.ipynb
+++ b/project-bikesharing/Predicting_bike_sharing_data.ipynb
@@ -360,7 +360,7 @@
     "for ii in range(iterations):\n",
     "    # Go through a random batch of 128 records from the training data set\n",
     "    batch = np.random.choice(train_features.index, size=128)\n",
-    "    X, y = train_features.ix[batch].values, train_targets.ix[batch]['cnt']\n",
+    "    X, y = train_features.iloc[batch].values, train_targets.iloc[batch]['cnt']\n",
     "                             \n",
     "    network.train(X, y)\n",
     "    \n",


### PR DESCRIPTION
.ix is deprecated so, it gives warnings for its usage.
Warning : c:\users\dell\appdata\local\programs\python\python37\lib\site-packages\ipykernel_launcher.py:16: DeprecationWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated
  app.launch_new_instance()

To suppress warnings, we can use .iloc