### PR TITLE
fixed table in markdown cell

### DIFF
--- a/project-dog-classification/dog_app.ipynb
+++ b/project-dog-classification/dog_app.ipynb
@@ -408,7 +408,7 @@
     "Likewise, recall that labradors come in yellow, chocolate, and black.  Your vision-based algorithm will have to conquer this high intra-class variation to determine how to classify all of these different shades as the same breed.  \n",
     "\n",
     "Yellow Labrador | Chocolate Labrador | Black Labrador\n",
-    "- | -\n",
+    "- | - | -\n",
     "<img src=\"images/Labrador_retriever_06457.jpg\" width=\"150\"> | <img src=\"images/Labrador_retriever_06455.jpg\" width=\"240\"> | <img src=\"images/Labrador_retriever_06449.jpg\" width=\"220\">\n",
     "\n",
     "We also mention that random chance presents an exceptionally low bar: setting aside the fact that the classes are slightly imabalanced, a random guess will provide a correct answer roughly 1 in 133 times, which corresponds to an accuracy of less than 1%.  \n",


### PR DESCRIPTION
the "Labrador" table was not being parsed because it was missing the closing border characters "-|"