### PR TITLE
update miniconda installation guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Using Anaconda consists of the following:
 
 **Install** [miniconda](http://conda.pydata.org/miniconda.html) on your machine. Detailed instructions:
 
-- **Linux:** http://conda.pydata.org/docs/install/quick.html#linux-miniconda-install
-- **Mac:** http://conda.pydata.org/docs/install/quick.html#os-x-miniconda-install
-- **Windows:** http://conda.pydata.org/docs/install/quick.html#windows-miniconda-install
+- **Linux:** https://conda.io/projects/conda/en/latest/user-guide/install/linux.html
+- **Mac:** https://conda.io/projects/conda/en/latest/user-guide/install/macos.html
+- **Windows:** https://conda.io/projects/conda/en/latest/user-guide/install/windows.html
 
 ## 2. Create and Activate the Environment
 


### PR DESCRIPTION
The current links to miniconda installation documentation are broken. I have updated them in the README to currently working urls