### PR TITLE
Small TODO fix

### DIFF
--- a/attention/Attention_Basics.ipynb
+++ b/attention/Attention_Basics.ipynb
@@ -148,7 +148,7 @@
    "outputs": [],
    "source": [
     "def dot_attention_score(dec_hidden_state, annotations):\n",
-    "    # TODO: return the product of dec_hidden_state transpose and enc_hidden_states\n",
+    "    # TODO: return the product of dec_hidden_state transpose and annotations\n",
     "    return \n",
     "    \n",
     "attention_weights_raw = dot_attention_score(dec_hidden_state, annotations)\n",


### PR DESCRIPTION
Return the product of dec_hidden_state transpose and annotations instead of enc_hidden_states in Attention Basics.
