### PR TITLE
[mnist_mlp_exercise] Remove Redundant np.sum() on a single cell

### DIFF
--- a/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
+++ b/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
@@ -322,7 +322,7 @@
     "    if class_total[i] > 0:\n",
     "        print('Test Accuracy of %5s: %2d%% (%2d/%2d)' % (\n",
     "            str(i), 100 * class_correct[i] / class_total[i],\n",
-    "            np.sum(class_correct[i]), np.sum(class_total[i])))\n",
+    "            class_correct[i], class_total[i]))\n",
     "    else:\n",
     "        print('Test Accuracy of %5s: N/A (no training examples)' % (classes[i]))\n",
     "\n",


### PR DESCRIPTION
class_correct[i] is a single cell and there is no need to be wrapped in np.sum(). I tested the output with the change to make sure it works.