### PR TITLE
Fixed typos in multiple jupyter notebooks

### DIFF
--- a/dcgan-svhn/DCGAN_Exercise.ipynb
+++ b/dcgan-svhn/DCGAN_Exercise.ipynb
@@ -374,7 +374,7 @@
     "\n",
     "The losses will by binary cross entropy loss with logits, which we can get with [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss). This combines a `sigmoid` activation function **and** and binary cross entropy loss in one function.\n",
     "\n",
-    "For the real images, we want `D(real_images) = 1`. That is, we want the discriminator to classify the the real images with a label = 1, indicating that these are real. The discriminator loss for the fake data is similar. We want `D(fake_images) = 0`, where the fake images are the _generator output_, `fake_images = G(z)`. \n",
+    "For the real images, we want `D(real_images) = 1`. That is, we want the discriminator to classify the real images with a label = 1, indicating that these are real. The discriminator loss for the fake data is similar. We want `D(fake_images) = 0`, where the fake images are the _generator output_, `fake_images = G(z)`. \n",
     "\n",
     "### Generator Loss\n",
     "\n",
@@ -671,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/dcgan-svhn/DCGAN_Solution.ipynb
+++ b/dcgan-svhn/DCGAN_Solution.ipynb
@@ -502,7 +502,7 @@
     "\n",
     "The losses will by binary cross entropy loss with logits, which we can get with [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss). This combines a `sigmoid` activation function **and** and binary cross entropy loss in one function.\n",
     "\n",
-    "For the real images, we want `D(real_images) = 1`. That is, we want the discriminator to classify the the real images with a label = 1, indicating that these are real. The discriminator loss for the fake data is similar. We want `D(fake_images) = 0`, where the fake images are the _generator output_, `fake_images = G(z)`. \n",
+    "For the real images, we want `D(real_images) = 1`. That is, we want the discriminator to classify the real images with a label = 1, indicating that these are real. The discriminator loss for the fake data is similar. We want `D(fake_images) = 0`, where the fake images are the _generator output_, `fake_images = G(z)`. \n",
     "\n",
     "### Generator Loss\n",
     "\n",
@@ -949,7 +949,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,3 @@
+[0201/085412.647:ERROR:file_io_win.cc(179)] CreateFile C:\Program Files (x86)\Cansuck\settings.dat: Access is denied. (0x5)
+[0201/085412.651:ERROR:registration_protocol_win.cc(84)] TransactNamedPipe: The pipe has been ended. (0x6D)
+[0201/085412.652:ERROR:file_io_win.cc(179)] CreateFile C:\Program Files (x86)\Cansuck\settings.dat: Access is denied. (0x5)

--- a/gan-mnist/MNIST_GAN_Exercise.ipynb
+++ b/gan-mnist/MNIST_GAN_Exercise.ipynb
@@ -122,7 +122,7 @@
     "#### Sigmoid Output\n",
     "\n",
     "We'll also take the approach of using a more numerically stable loss function on the outputs. Recall that we want the discriminator to output a value 0-1 indicating whether an image is _real or fake_. \n",
-    "> We will ultimately use [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss), which combines a `sigmoid` activation function **and** and binary cross entropy loss in one function. \n",
+    "> We will ultimately use [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss), which combines a `sigmoid` activation function **and** binary cross entropy loss in one function. \n",
     "\n",
     "So, our final output layer should not have any activation function applied to it."
    ]
@@ -601,7 +601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/gan-mnist/MNIST_GAN_Solution.ipynb
+++ b/gan-mnist/MNIST_GAN_Solution.ipynb
@@ -147,7 +147,7 @@
     "#### Sigmoid Output\n",
     "\n",
     "We'll also take the approach of using a more numerically stable loss function on the outputs. Recall that we want the discriminator to output a value 0-1 indicating whether an image is _real or fake_. \n",
-    "> We will ultimately use [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss), which combines a `sigmoid` activation function **and** and binary cross entropy loss in one function. \n",
+    "> We will ultimately use [BCEWithLogitsLoss](https://pytorch.org/docs/stable/nn.html#bcewithlogitsloss), which combines a `sigmoid` activation function **and** binary cross entropy loss in one function. \n",
     "\n",
     "So, our final output layer should not have any activation function applied to it."
    ]
@@ -1078,7 +1078,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed some typos like multiple "and" and "the" in DC GAN and MNIST GAN exercise and solution notebooks.