### PR TITLE
Rectifying error in comments

### DIFF
--- a/gan-mnist/MNIST_GAN_Exercise.ipynb
+++ b/gan-mnist/MNIST_GAN_Exercise.ipynb
@@ -220,7 +220,7 @@
     "\n",
     "# Size of latent vector to give to generator\n",
     "z_size = \n",
-    "# Size of discriminator output (generated image)\n",
+    "# Size of generator output (generated image)\n",
     "g_output_size = \n",
     "# Size of *first* hidden layer in the generator\n",
     "g_hidden_size = "


### PR DESCRIPTION
Should be generator instead of discriminator.