### PR TITLE
Fix for helpers.hist_dist() crash in weight_initialization notebook

### DIFF
--- a/weight-initialization/helpers.py
+++ b/weight-initialization/helpers.py
@@ -105,5 +105,5 @@ def hist_dist(title, distribution_tensor, hist_range=(-4, 4)):
     Display histogram of values in a given distribution tensor
     """
     plt.title(title)
-    plt.hist(distribution_tensor, np.linspace(*hist_range, num=len(distribution_tensor)/2))
+    plt.hist(distribution_tensor, np.linspace(*hist_range, num=len(distribution_tensor)//2))
     plt.show()


### PR DESCRIPTION
The plt.hist function requires its "num" parameter to be an integer.
However, in helpers.hist_dist(), the argument value for this parameter
is calculated using regular ("/") division operator, which in Python 3
returns a float. This causes an exception when the value is passed
to plt.hist.

Note that this code would work correctly in Python 2, where the regular
division operator returns integers.

The fix here is trivial: simply use the integer division operator
("//"), which will return an integer in both Python 2 and 3.