### PR TITLE
Fixing Key error in predict

### DIFF
--- a/sentiment-rnn/Sentiment_RNN_Solution.ipynb
+++ b/sentiment-rnn/Sentiment_RNN_Solution.ipynb
@@ -1013,7 +1013,7 @@
     "\n",
     "    # tokens\n",
     "    test_ints = []\n",
-    "    test_ints.append([vocab_to_int[word] for word in test_words])\n",
+    "    test_ints.append([vocab_to_int.get(word, 0) for word in test_words])\n",
     "\n",
     "    return test_ints\n",
     "\n",


### PR DESCRIPTION
Due to some words are not present in the dictionary of words that cause a problem of key error if we try to use it any other example 
:
``` 
test_review_neg = " Ice-Cubes character is a bit forced, but it has some appealing moments." ```  in this "Icecube" lead to Key error because this is not present in the model while adding a dictionary so to held this there was no code.

I change  to "test_ints.append([vocab_to_int.get(word, 0) for word in test_words])"
 from "test_ints.append([vocab_to_int[word] for word in test_words])"

this solve the Key error if somebody wants to try out with any other example