### PR TITLE
Fixing filename in .udacity-pa for bikesharing project

### DIFF
--- a/project-bikesharing/.udacity-pa/projects.py
+++ b/project-bikesharing/.udacity-pa/projects.py
@@ -4,7 +4,7 @@ from udacity_pa import udacity
 
 nanodegree = 'nd101'
 projects = ['first_neural_network']
-filenames = ['my_answers.py', 'Your_first_neural_network.ipynb']
+filenames = ['my_answers.py', 'Predicting_bike_sharing_data.ipynb']
 
 def submit(args):
 


### PR DESCRIPTION
The ipynb file for bikesharing project has been renamed, but .udacity-pa/projects.py wasn't updated with the same changes. This is causing an exception when submitting a project, which requires filename change. 