### PR TITLE
Remove "_" from conv layer names to match figures.

### DIFF
--- a/style-transfer/Style_Transfer_Exercise.ipynb
+++ b/style-transfer/Style_Transfer_Exercise.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "In this notebook, we’ll *recreate* a style transfer method that is outlined in the paper, [Image Style Transfer Using Convolutional Neural Networks, by Gatys](https://www.cv-foundation.org/openaccess/content_cvpr_2016/papers/Gatys_Image_Style_Transfer_CVPR_2016_paper.pdf) in PyTorch.\n",
     "\n",
-    "In this paper, style transfer uses the features found in the 19-layer VGG Network, which is comprised of a series of convolutional and pooling layers, and a few fully-connected layers. In the image below, the convolutional layers are named by stack and their order in the stack. Conv_1_1 is the first convolutional layer that an image is passed through, in the first stack. Conv_2_1 is the first convolutional layer in the *second* stack. The deepest convolutional layer in the network is conv_5_4.\n",
+    "In this paper, style transfer uses the features found in the 19-layer VGG Network, which is comprised of a series of convolutional and pooling layers, and a few fully-connected layers. In the image below, the convolutional layers are named by stack and their order in the stack. Conv1_1 is the first convolutional layer that an image is passed through, in the first stack. Conv2_1 is the first convolutional layer in the *second* stack. The deepest convolutional layer in the network is conv5_4.\n",
     "\n",
     "<img src='notebook_ims/vgg19_convlayers.png' width=80% />\n",
     "\n",


### PR DESCRIPTION
A simple fix to make explanation and figures match naming conventions