### PR TITLE
  fixed syntax error

### DIFF
--- a/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
+++ b/intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
@@ -316,7 +316,7 @@
    ],
    "source": [
     "import numpy as np\n",
-    "np.set_printoptions(precision=8)",
+    "np.set_printoptions(precision=8)\n",
     "a = np.random.rand(4,3)\n",
     "a"
    ]
@@ -336,7 +336,7 @@
     }
    ],
    "source": [
-    "torch.set_printoptions(precision=8)",
+    "torch.set_printoptions(precision=8)\n",
     "b = torch.from_numpy(a)\n",
     "b"
    ]


### PR DESCRIPTION
🐛 added a space in execution count, **78** and **79**

![typo](https://user-images.githubusercontent.com/57009004/115614229-1bfaae00-a2f6-11eb-80a5-a21abe037aee.jpg)
