### PR TITLE
Typo in line  324 "Postive" need to be "Positive"

### DIFF
--- a/sentiment-analysis-network/Sentiment_Classification_Projects.ipynb
+++ b/sentiment-analysis-network/Sentiment_Classification_Projects.ipynb
@@ -321,7 +321,7 @@
     "\n",
     "Ok, the ratios tell us which words are used more often in postive or negative reviews, but the specific values we've calculated are a bit difficult to work with. A very positive word like \"amazing\" has a value above 4, whereas a very negative word like \"terrible\" has a value around 0.18. Those values aren't easy to compare for a couple of reasons:\n",
     "\n",
-    "* Right now, 1 is considered neutral, but the absolute value of the postive-to-negative rations of very postive words is larger than the absolute value of the ratios for the very negative words. So there is no way to directly compare two numbers and see if one word conveys the same magnitude of positive sentiment as another word conveys negative sentiment. So we should center all the values around netural so the absolute value fro neutral of the postive-to-negative ratio for a word would indicate how much sentiment (positive or negative) that word conveys.\n",
+    "* Right now, 1 is considered neutral, but the absolute value of the positive-to-negative ratios of very positive words is larger than the absolute value of the ratios for the very negative words. So there is no way to directly compare two numbers and see if one word conveys the same magnitude of positive sentiment as another word conveys negative sentiment. So we should center all the values around netural so the absolute value fro neutral of the postive-to-negative ratio for a word would indicate how much sentiment (positive or negative) that word conveys.\n",
     "* When comparing absolute values it's easier to do that around zero than one. \n",
     "\n",
     "To fix these issues, we'll convert all of our ratios to new values using logarithms.\n",


### PR DESCRIPTION
This change is regarding a typo error in the line 324 with the word "postive" which is according to the description of the paragraph the word must be "positive" and "rations" to be "ratios"