### PR TITLE
fix: Scale the targets for test data

### DIFF
--- a/project-bikesharing/Predicting_bike_sharing_data.ipynb
+++ b/project-bikesharing/Predicting_bike_sharing_data.ipynb
@@ -134,7 +134,8 @@
     "for each in quant_features:\n",
     "    mean, std = data[each].mean(), data[each].std()\n",
     "    scaled_features[each] = [mean, std]\n",
-    "    data.loc[:, each] = (data[each] - mean)/std"
+    "    data.loc[:, each] = (data[each] - mean)/std\n"
+    "    test_data.loc[:, each] = (test_data[each] - mean)/std"
    ]
   },
   {


### PR DESCRIPTION
I came across a problem where the model prediction is not being updated on the graph in the 'Check Out Your Predictions' section of the notebook because the test data was not scaled. See the following Udacity mentor's comments on the Knowledge platform for reference: https://knowledge.udacity.com/questions/510089