### PR TITLE
Add drop_last to Sentiment_RNN_Solution.ipynb

### DIFF
--- a/sentiment-rnn/Sentiment_RNN_Solution.ipynb
+++ b/sentiment-rnn/Sentiment_RNN_Solution.ipynb
@@ -402,9 +402,9 @@
     "batch_size = 50\n",
     "\n",
     "# make sure the SHUFFLE your training data\n",
-    "train_loader = DataLoader(train_data, shuffle=True, batch_size=batch_size)\n",
-    "valid_loader = DataLoader(valid_data, shuffle=True, batch_size=batch_size)\n",
-    "test_loader = DataLoader(test_data, shuffle=True, batch_size=batch_size)"
+    "train_loader = DataLoader(train_data, shuffle=True, batch_size=batch_size, drop_last = True)\n",
+    "valid_loader = DataLoader(valid_data, shuffle=True, batch_size=batch_size, drop_last = True)\n",
+    "test_loader = DataLoader(test_data, shuffle=True, batch_size=batch_size, drop_last = True)"
    ]
   },
   {


### PR DESCRIPTION
When I tried to change the batch_size in the notebook from 50 to 64, I encountered the following error:

`RuntimeError: Expected hidden[0] size (2, 4, 256), got (2, 64, 256)`

It's because we have `20000` training samples and `2500` validation and test samples. Previously there was no error since these numbers are divisible by 50, which is the original batch_size in the solution notebook. Still, when someone wants to experiment with other batch sizes that are not divisible, they will encounter the mentioned error. So I added `drop_last` to the notebook so students can experiment with other batch sizes and will not be surprised due to this error.