### PR TITLE
Fix link to torchvision datasets.

### DIFF
--- a/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
+++ b/convolutional-neural-networks/mnist-mlp/mnist_mlp_exercise.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## Load and Visualize the [Data](http://pytorch.org/docs/stable/torchvision/datasets.html)\n",
+    "## Load and Visualize the [Data](https://pytorch.org/vision/stable/datasets.html)\n",
     "\n",
     "Downloading may take a few moments, and you should see your progress as the data is loading. You may also choose to change the `batch_size` if you want to load more data at a time.\n",
     "\n",


### PR DESCRIPTION
The MNIST exercise notebook contains an outdated link to the torchvision datasets documentation.

I've updated this link to point to the new location of that documentation.