### PR TITLE
Convert boolean features to float in training data

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -20,9 +20,90 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>admit</th>\n",
+       "      <th>gre</th>\n",
+       "      <th>gpa</th>\n",
+       "      <th>rank</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>380</td>\n",
+       "      <td>3.61</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>660</td>\n",
+       "      <td>3.67</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>800</td>\n",
+       "      <td>4.00</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>640</td>\n",
+       "      <td>3.19</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>520</td>\n",
+       "      <td>2.93</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   admit  gre   gpa  rank\n",
+       "0      0  380  3.61     3\n",
+       "1      1  660  3.67     3\n",
+       "2      1  800  4.00     1\n",
+       "3      1  640  3.19     4\n",
+       "4      0  520  2.93     4"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Importing pandas and numpy\n",
     "import pandas as pd\n",
@@ -184,11 +265,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Splitting the data into features and targets (labels)\n",
-    "Now, as a final step before the training, we'll split the data into features (X) and targets (y)."
+    "Now, as a final step before the training, we'll split the data into features (X) and targets (y). We must also convert the boolean true and falses from the one hot encoded ranks to numbers by representing them as a float."
    ]
   },
   {
@@ -201,6 +283,7 @@
     "targets = train_data['admit']\n",
     "features_test = test_data.drop('admit', axis=1)\n",
     "targets_test = test_data['admit']\n",
+    "features = features.astype(float)\n",
     "\n",
     "print(features[:10])\n",
     "print(targets[:10])"
@@ -354,7 +437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This commit addresses a type mismatch issue in the neural network training function. The one-hot encoded rank features in the training data were boolean values, which caused a UFuncTypeError when trying to perform operations with float values in the error term formula.

To fix this, we've added a line to convert all features in the training data to float. This converts the boolean rank features to numerical values (1.0 for True, 0.0 for False), which can be used in the error term formula without causing type errors.

We've also updated the markdown documentation to explain this conversion.

Changes:
- Add line to convert features to float in training data
- Update markdown documentation to explain boolean to float conversion