### PR TITLE
Convert boolean features to float in training data

### DIFF
--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -188,7 +188,7 @@
    "metadata": {},
    "source": [
     "## Splitting the data into features and targets (labels)\n",
-    "Now, as a final step before the training, we'll split the data into features (X) and targets (y)."
+    "Now, as a final step before the training, we'll split the data into features (X) and targets (y). We must also convert the values in the one hot encoded ranks from a boolean (true or false) to a float (1 or 0)."
    ]
   },
   {
@@ -201,6 +201,7 @@
     "targets = train_data['admit']\n",
     "features_test = test_data.drop('admit', axis=1)\n",
     "targets_test = test_data['admit']\n",
+    "features = features.astype(float)\n",
     "\n",
     "print(features[:10])\n",
     "print(targets[:10])"

--- a/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
+++ b/intro-neural-networks/student-admissions/StudentAdmissions.ipynb
@@ -325,7 +325,7 @@
    "outputs": [],
    "source": [
     "# Calculate accuracy on test data\n",
-    "test_out = sigmoid(np.dot(features_test, weights))\n",
+    "test_out = sigmoid(np.dot(features_test.astype(float), weights))\n",
     "predictions = test_out > 0.5\n",
     "accuracy = np.mean(predictions == targets_test)\n",
     "print(\"Prediction accuracy: {:.3f}\".format(accuracy))"


### PR DESCRIPTION
This commit addresses a type mismatch issue in the neural network training function. The one-hot encoded rank features in the training data were boolean values, which caused a UFuncTypeError when trying to perform operations with float values in the error term formula.

To fix this, we've added a line to convert all features in the training data to float. This converts the boolean rank features to numerical values (1.0 for True, 0.0 for False), which can be used in the error term formula without causing type errors.

We've also updated the markdown documentation to explain this conversion.